### PR TITLE
Remove file argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 
 # others
 dlcov_references_test.dart
+coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ example:
 ```shell
 dlcov -c 80 -p flutter_project_name
 dlcov -c 80 --package-name flutter_project_name
+
+- Remove `file` argument (always uses default: coverage/lcov.info)
 ```
 #### Added
 - workaround to make it consider all dart files in code coverage reports (It is not yet natively supported by Flutter.)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ### Usage Example
 #### Long
-`dlcov --file=path/to/lcov.info --coverage=80 --exclude-sufix=.g.dart,.freezed.dart --log=true`  
+`dlcov --coverage=80 --exclude-sufix=.g.dart,.freezed.dart --log=true`  
 #### Short
-`dlcov -f ./lcov.info -c 80 -e .g.dart,.freezed.dart -l true`
+`dlcov -c 80 -e .g.dart,.freezed.dart -l true`
   
 #### Using Flutter defaults
 `dlcov -c 80`
@@ -16,7 +16,7 @@
 | Long | Short | Mandatory | Default | Sample | Description |
 |---|---|---|---|---|---|
 | --coverage | -c | true |  | 80.0 | min coverage target |
-| --file | -f | false | coverage/lcov.info | ./lcov.info | relative lcov file path |
+| --package-name | -p | false | current dir name | dlcov | Use this, if root folder is not the same as the package name |
 | --log | -l | false | false | true | Log every test coverage info in dlcov.log  - Limit up to 1000 lines |
 | --exclude-sufix | -e | false | .g.dart,.freezed.dart | .g.dart | Remove generated files from test coverage results, separated by commas |
 

--- a/bin/dlcov.dart
+++ b/bin/dlcov.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:dlcov/core/app_constants.dart';
+import 'package:dlcov/entities/config.dart';
 import 'package:dlcov/repositories/config_repostory.dart';
 import 'package:dlcov/repositories/record_repository.dart';
 import 'package:dlcov/usecases/create_file_references.dart';
@@ -13,20 +15,28 @@ import 'package:dlcov/utils/file_system/file_system_util.dart';
 
 void main(List<String> arguments) async {
   final parser = ArgParser();
+  final Config config;
 
   parser.addFlag('help',
       defaultsTo: false, abbr: 'h', callback: showHelpAndExit);
 
   final argResults = ParseArguments().getArgResults(arguments, parser);
-  final config = GetConfig(ConfigRepository(argResults), parser)();
+  config = GetConfig(ConfigRepository(argResults), parser)();
 
   // Create references for all dart files
-  await CreateFileReferences(CreateFileReferencesHelper(FileSystemUtil()),
-          'lib', config.excludeSufixes, config.packageName)
+  await CreateFileReferences(
+          CreateFileReferencesHelper(FileSystemUtil()),
+          AppConstants.sourceDirectory,
+          config.excludeSufixes,
+          config.packageName)
       .call();
 
+  // Generate lcov.info
+  await Process.run('flutter', ['test', '--coverage']);
+
   // Verify minimum coverage threshold
-  final getLcov = GetLcov(config, GetRecords(RecordsRepository(config.file)));
+  final getLcov = GetLcov(
+      config, GetRecords(RecordsRepository(AppConstants.lcovPathDefaultValue)));
   VerifyCoverage()(await getLcov());
 }
 
@@ -34,11 +44,10 @@ showHelpAndExit(bool help) {
   if (help) {
     print('\nLong\t\tShort\tMandatory\tDefault\t\t\tSample\t\tDescription\n\n'
         '--coverage\t-c\ttrue\t\t80.0\t\t\t\t\tMin coverage threshold\n'
-        '--file\t\t-f\tfalse\t\tcoverage/lcov.info\t./lcov.info	Relative lcov file path\n'
         '--log\t\t-l\tfalse\t\tfalse\t\t\ttrue\t\tLog every test coverage info in dlcov.log - Limit up to 1000 lines\n'
         '--exclude-sufix\t-e\tfalse\t\t.g.dart,.freezed.dart\t.g.dart\t\tRemove generated files from test coverage results, separated by commas\n'
         '--package-name\t-p\tfalse\t\tcurr dir name\t\tdlcov\t\tUse this, if root folder is not the same as the package name\n\n'
-        'Example: dlcov -f coverage/lcov.info -c 80\n');
+        'Example: dlcov -c 80\n');
     exit(0);
   }
 }

--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -1,13 +1,11 @@
 /// [AppConstants]
 class AppConstants {
-  static String argLongFile = 'file';
   static String argLongCoverage = 'coverage';
   static String argLongExcludeSufix = 'exclude-sufix';
   static String argLongLog = 'log';
   static String argLongHelp = 'help';
   static String argLongPackageName = 'package-name';
 
-  static String argShortFile = 'f';
   static String argShortCoverage = 'c';
   static String argShortExcludeSufix = 'e';
   static String argShortLog = 'l';
@@ -20,9 +18,9 @@ class AppConstants {
 
   static String dlcovLogFile = './dlcov.log';
   static int maxLogLines = 1000;
-  static String fileSystemExceptionMessage =
-      '\nDid you forget to run flutter test --coverage?\n\n'
-      'Please run "flutter test --coverage" or enter a valid lcov.info file.\ne.g. "-f path/to/lcov.info"\n';
+  static String fileSystemExceptionMessage = '\nSomething went wrong!\n\n';
 
   static String dlcovFileReferences = 'test/dlcov_references_test.dart';
+
+  static String sourceDirectory = 'lib';
 }

--- a/lib/entities/config.dart
+++ b/lib/entities/config.dart
@@ -1,14 +1,12 @@
 /// Config entity
 class Config {
-  final String file;
   final double percentage;
   final List<String> excludeSufixes;
   final bool log;
   final String? packageName;
 
   Config(
-      {required this.file,
-      required this.percentage,
+      {required this.percentage,
       required this.excludeSufixes,
       required this.log,
       this.packageName});

--- a/lib/entities/lcov.dart
+++ b/lib/entities/lcov.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:dlcov/core/app_constants.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 
+import '../core/app_constants.dart';
 import 'config.dart';
 import 'coverage.dart';
 
@@ -35,8 +35,9 @@ class Lcov {
 
       final totalCoverage = (totalHits / totalFinds) * 100;
       coverage.totalCoverage = totalCoverage;
-    } on FileSystemException {
+    } on FileSystemException catch (e) {
       print(AppConstants.fileSystemExceptionMessage);
+      print(e);
       rethrow;
     } catch (e) {
       print(e);

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -1,8 +1,5 @@
 /// Config model
 class ConfigModel {
-  /// file
-  final String file;
-
   /// percentage
   final double percentage;
 
@@ -15,8 +12,7 @@ class ConfigModel {
   final String? packageName;
 
   ConfigModel(
-      {required this.file,
-      required this.percentage,
+      {required this.percentage,
       required this.excludeSufixes,
       required this.log,
       this.packageName});

--- a/lib/repositories/config_repostory.dart
+++ b/lib/repositories/config_repostory.dart
@@ -10,14 +10,12 @@ class ConfigRepository {
 
   /// Execute usecase
   ConfigModel call() {
-    late String file;
     late double percentage;
     late List<String> excludeSufixes;
     late bool log;
     late String? packageName;
 
     try {
-      file = argResults[AppConstants.argLongFile];
       percentage = double.parse(argResults[AppConstants.argLongCoverage]);
       final String excludesResult =
           argResults[AppConstants.argLongExcludeSufix];
@@ -35,7 +33,6 @@ class ConfigRepository {
     }
 
     return ConfigModel(
-        file: file,
         percentage: percentage,
         excludeSufixes: excludeSufixes,
         log: log,

--- a/lib/repositories/record_repository.dart
+++ b/lib/repositories/record_repository.dart
@@ -14,8 +14,9 @@ class RecordsRepository {
     late List<Record> records;
     try {
       records = await Parser.parse(_file);
-    } on FileSystemException {
+    } on FileSystemException catch (e) {
       print(AppConstants.fileSystemExceptionMessage);
+      print(e);
     } catch (e) {
       rethrow;
     }

--- a/lib/usecases/get_config.dart
+++ b/lib/usecases/get_config.dart
@@ -14,7 +14,6 @@ class GetConfig {
     return Config(
         percentage: configModel.percentage,
         log: configModel.log,
-        file: configModel.file,
         excludeSufixes: configModel.excludeSufixes,
         packageName: configModel.packageName);
   }

--- a/lib/usecases/parse_arguments.dart
+++ b/lib/usecases/parse_arguments.dart
@@ -5,11 +5,6 @@ import '../core/app_constants.dart';
 class ParseArguments {
   /// Return argResults
   ArgResults getArgResults(List<String> arguments, ArgParser parser) {
-    parser.addOption(AppConstants.argLongFile,
-        abbr: AppConstants.argShortFile,
-        defaultsTo: AppConstants.lcovPathDefaultValue,
-        mandatory: false);
-
     parser.addOption(AppConstants.argLongCoverage,
         abbr: AppConstants.argShortCoverage, mandatory: true);
 


### PR DESCRIPTION
#### Break
Remove `file` argument, and now it uses `coverage/lcov.info` as default.