### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ### Usage Example
 #### Long
-`dlcov --coverage=80 --exclude-suffix=.g.dart,.freezed.dart --log=true`  
+`dlcov --coverage=80 --exclude-suffix=.g.dart,.freezed.dart --log=true`
 #### Short
 `dlcov -c 80 -e .g.dart,.freezed.dart -l true`
-  
+
 #### Using Flutter defaults
 `dlcov -c 80`
 
-### Install 
+### Install
 `pub global activate dlcov`
 
 ## Parameters availables
@@ -20,8 +20,8 @@
 | --log | -l | false | false | true | Log every test coverage info in dlcov.log  - Limit up to 1000 lines |
 | --exclude-suffix | -e | false | .g.dart,.freezed.dart | .g.dart | Remove generated files from test coverage results, separated by commas |
 
-### Github actions  
-  
-if the test coverage is less than 80, it stop the pipeline here, and abort the actions  
-  
+### Github actions
+
+if the test coverage is less than 80, it stop the pipeline here, and abort the actions
+
 <img width="605" alt="ScreenShot" src="https://user-images.githubusercontent.com/3827308/137652713-497c726a-5f56-4a63-b59b-3c135d6921ec.png">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Usage Example
 #### Long
-`dlcov --coverage=80 --exclude-sufix=.g.dart,.freezed.dart --log=true`  
+`dlcov --coverage=80 --exclude-suffix=.g.dart,.freezed.dart --log=true`  
 #### Short
 `dlcov -c 80 -e .g.dart,.freezed.dart -l true`
   
@@ -18,7 +18,7 @@
 | --coverage | -c | true |  | 80.0 | min coverage target |
 | --package-name | -p | false | current dir name | dlcov | Use this, if root folder is not the same as the package name |
 | --log | -l | false | false | true | Log every test coverage info in dlcov.log  - Limit up to 1000 lines |
-| --exclude-sufix | -e | false | .g.dart,.freezed.dart | .g.dart | Remove generated files from test coverage results, separated by commas |
+| --exclude-suffix | -e | false | .g.dart,.freezed.dart | .g.dart | Remove generated files from test coverage results, separated by commas |
 
 ### Github actions  
   

--- a/bin/dlcov.dart
+++ b/bin/dlcov.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:dlcov/core/app_constants.dart';
 import 'package:dlcov/entities/config.dart';
-import 'package:dlcov/repositories/config_repostory.dart';
+import 'package:dlcov/repositories/config_repository.dart';
 import 'package:dlcov/repositories/record_repository.dart';
 import 'package:dlcov/usecases/create_file_references.dart';
 import 'package:dlcov/usecases/get_config.dart';
@@ -27,7 +27,7 @@ void main(List<String> arguments) async {
   await CreateFileReferences(
           CreateFileReferencesHelper(FileSystemUtil()),
           AppConstants.sourceDirectory,
-          config.excludeSufixes,
+          config.excludeSuffixes,
           config.packageName)
       .call();
 
@@ -46,7 +46,7 @@ showHelpAndExit(bool help) {
     print('\nLong\t\tShort\tMandatory\tDefault\t\t\tSample\t\tDescription\n\n'
         '--coverage\t-c\ttrue\t\t80.0\t\t\t\t\tMin coverage threshold\n'
         '--log\t\t-l\tfalse\t\tfalse\t\t\ttrue\t\tLog every test coverage info in dlcov.log - Limit up to 1000 lines\n'
-        '--exclude-sufix\t-e\tfalse\t\t.g.dart,.freezed.dart\t.g.dart\t\tRemove generated files from test coverage results, separated by commas\n'
+        '--exclude-suffix\t-e\tfalse\t\t.g.dart,.freezed.dart\t.g.dart\t\tRemove generated files from test coverage results, separated by commas\n'
         '--package-name\t-p\tfalse\t\tcurr dir name\t\tdlcov\t\tUse this, if root folder is not the same as the package name\n\n'
         'Example: dlcov -c 80\n');
     exit(0);

--- a/lib/core/app_constants.dart
+++ b/lib/core/app_constants.dart
@@ -1,19 +1,19 @@
 /// [AppConstants]
 class AppConstants {
   static String argLongCoverage = 'coverage';
-  static String argLongExcludeSufix = 'exclude-sufix';
+  static String argLongExcludeSuffix = 'exclude-suffix';
   static String argLongLog = 'log';
   static String argLongHelp = 'help';
   static String argLongPackageName = 'package-name';
 
   static String argShortCoverage = 'c';
-  static String argShortExcludeSufix = 'e';
+  static String argShortExcludeSuffix = 'e';
   static String argShortLog = 'l';
   static String argShortHelp = 'h';
   static String argShortPackageName = 'p';
 
   static String falseAsStringValue = 'false';
-  static String excludeSufixDefaultValue = '.g.dart,.freezed.dart,.part.dart';
+  static String excludeSuffixDefaultValue = '.g.dart,.freezed.dart,.part.dart';
   static String lcovPathDefaultValue = 'coverage/lcov.info';
 
   static String dlcovLogFile = './dlcov.log';

--- a/lib/entities/config.dart
+++ b/lib/entities/config.dart
@@ -1,13 +1,13 @@
 /// Config entity
 class Config {
   final double percentage;
-  final List<String> excludeSufixes;
+  final List<String> excludeSuffixes;
   final bool log;
   final String? packageName;
 
   Config(
       {required this.percentage,
-      required this.excludeSufixes,
+      required this.excludeSuffixes,
       required this.log,
       this.packageName});
 }

--- a/lib/entities/lcov.dart
+++ b/lib/entities/lcov.dart
@@ -29,7 +29,7 @@ class Lcov {
       coverage = Coverage(config.percentage);
 
       records =
-          records.where((element) => !hasSufix(element.file ?? '')).toList();
+          records.where((element) => !hasSuffix(element.file ?? '')).toList();
 
       records.forEach(updateTotals);
 
@@ -45,10 +45,10 @@ class Lcov {
     }
   }
 
-  /// Check if has sufix
-  bool hasSufix(String value) {
+  /// Check if has suffix
+  bool hasSuffix(String value) {
     final matchList =
-        config.excludeSufixes.where((element) => value.endsWith(element));
+        config.excludeSuffixes.where((element) => value.endsWith(element));
     return matchList.isNotEmpty;
   }
 

--- a/lib/models/config_model.dart
+++ b/lib/models/config_model.dart
@@ -3,7 +3,7 @@ class ConfigModel {
   /// percentage
   final double percentage;
 
-  final List<String> excludeSufixes;
+  final List<String> excludeSuffixes;
 
   /// log
   final bool log;
@@ -13,7 +13,7 @@ class ConfigModel {
 
   ConfigModel(
       {required this.percentage,
-      required this.excludeSufixes,
+      required this.excludeSuffixes,
       required this.log,
       this.packageName});
 }

--- a/lib/repositories/config_repository.dart
+++ b/lib/repositories/config_repository.dart
@@ -11,15 +11,15 @@ class ConfigRepository {
   /// Execute usecase
   ConfigModel call() {
     late double percentage;
-    late List<String> excludeSufixes;
+    late List<String> excludeSuffixes;
     late bool log;
     late String? packageName;
 
     try {
       percentage = double.parse(argResults[AppConstants.argLongCoverage]);
       final String excludesResult =
-          argResults[AppConstants.argLongExcludeSufix];
-      excludeSufixes = excludesResult
+          argResults[AppConstants.argLongExcludeSuffix];
+      excludeSuffixes = excludesResult
           .split(',')
           .map((e) => e.trim())
           .where((element) => element != '')
@@ -34,7 +34,7 @@ class ConfigRepository {
 
     return ConfigModel(
         percentage: percentage,
-        excludeSufixes: excludeSufixes,
+        excludeSuffixes: excludeSuffixes,
         log: log,
         packageName: packageName);
   }

--- a/lib/usecases/create_file_references.dart
+++ b/lib/usecases/create_file_references.dart
@@ -6,14 +6,14 @@ import '../utils/file_system/file_system_util.dart';
 
 class CreateFileReferences {
   final String _sourceDirectory;
-  final List<String> _removeFileWithSufixes;
+  final List<String> _removeFileWithSuffixes;
   final CreateFileReferencesHelper _helper;
   final String? _packageName;
 
   CreateFileReferences(
     this._helper,
     this._sourceDirectory, [
-    this._removeFileWithSufixes = const [],
+    this._removeFileWithSuffixes = const [],
     String? packageName,
   ]) : _packageName = packageName ??= Directory.current.path.split('/').last;
 
@@ -21,8 +21,8 @@ class CreateFileReferences {
     final fileSytemEntities =
         await _helper.getFileSystemEntities(Directory(_sourceDirectory));
 
-    final filteredFilePaths =
-        _helper.getFilteredFilePaths(fileSytemEntities, _removeFileWithSufixes);
+    final filteredFilePaths = _helper.getFilteredFilePaths(
+        fileSytemEntities, _removeFileWithSuffixes);
 
     final fileImports = [
       '/*\n'
@@ -53,7 +53,7 @@ class CreateFileReferencesHelper {
   CreateFileReferencesHelper(this.fileSystemUtil);
 
   getImportsList(List<FileSystemEntity> fileSytemEntities,
-      List<String> removeFileWithSufixes) {}
+      List<String> removeFileWithSuffixes) {}
 
   Future<List<FileSystemEntity>> getFileSystemEntities(Directory dir) {
     final files = <FileSystemEntity>[];
@@ -69,12 +69,12 @@ class CreateFileReferencesHelper {
   }
 
   List<String> getFilteredFilePaths(List<FileSystemEntity> fileSytemEntities,
-      List<String> removeFileWithSufixes) {
+      List<String> removeFileWithSuffixes) {
     return fileSytemEntities
         .where((fileSystemEntity) {
           return fileSystemEntity.path.endsWith('.dart') &&
-              !removeFileWithSufixes
-                  .any((sufix) => fileSystemEntity.path.endsWith(sufix));
+              !removeFileWithSuffixes
+                  .any((suffix) => fileSystemEntity.path.endsWith(suffix));
         })
         .map((e) => e.path)
         .toList();

--- a/lib/usecases/get_config.dart
+++ b/lib/usecases/get_config.dart
@@ -1,7 +1,7 @@
 import 'package:args/args.dart';
 
 import '../entities/config.dart';
-import '../repositories/config_repostory.dart';
+import '../repositories/config_repository.dart';
 
 class GetConfig {
   final ConfigRepository repository;
@@ -14,7 +14,7 @@ class GetConfig {
     return Config(
         percentage: configModel.percentage,
         log: configModel.log,
-        excludeSufixes: configModel.excludeSufixes,
+        excludeSuffixes: configModel.excludeSuffixes,
         packageName: configModel.packageName);
   }
 }

--- a/lib/usecases/parse_arguments.dart
+++ b/lib/usecases/parse_arguments.dart
@@ -8,9 +8,9 @@ class ParseArguments {
     parser.addOption(AppConstants.argLongCoverage,
         abbr: AppConstants.argShortCoverage, mandatory: true);
 
-    parser.addOption(AppConstants.argLongExcludeSufix,
-        abbr: AppConstants.argShortExcludeSufix,
-        defaultsTo: AppConstants.excludeSufixDefaultValue,
+    parser.addOption(AppConstants.argLongExcludeSuffix,
+        abbr: AppConstants.argShortExcludeSuffix,
+        defaultsTo: AppConstants.excludeSuffixDefaultValue,
         mandatory: false);
 
     parser.addOption(AppConstants.argLongLog,


### PR DESCRIPTION
I think sufix should be suffix.

As long as I was going to report it, I also checked in general with something like the following:

```
find . -name '*.dart' -print -exec ispell {} \;
```

I fumbled the keys halfway through the process, and finished it off in Emacs with something like the following:

```
M-x find-name-dired RET *.dart RET t Q sufix RET suffix RET Y
```

Similarly for `*.md` and `' +$' -> ''`.

I also checked `dart format . --fix` and `dart test`.

Let me know if you prefer prefixes, lowercase or one-liners in the commit title and body. And if you want an extra commit for the dart format change, or the two current commits squashed as one.

~~Oh, it's an API change, maybe I shouldn't have edited CHANGELOG.md.~~ I reverted the editing of `--exclude-sufix` in CHANGELOG.md and force pushed.